### PR TITLE
(three-tier-app-backend-qa-qa): upgrade image to 1.0.9

### DIFF
--- a/three-tier-app/backend/overlay/qa/kustomization.yaml
+++ b/three-tier-app/backend/overlay/qa/kustomization.yaml
@@ -19,4 +19,4 @@ patches:
       value: backend-service-qa
 images:
 - name: ghcr.io/kishoredurai/three-tier-applications/backend
-  newTag: 1.0.7
+  newTag: 1.0.9


### PR DESCRIPTION
(three-tier-app-backend-qa-qa): upgrade image to 1.0.9


[View in Kargo UI](https://localhost/project/three-tier-app/stage/three-tier-app-backend-qa)